### PR TITLE
Fix for AIAPI GetNPC non unique identifier

### DIFF
--- a/src/AIAPI/MainGame/GameExtensions.cs
+++ b/src/AIAPI/MainGame/GameExtensions.cs
@@ -76,7 +76,7 @@ namespace KKAPI.MainGame
 			{
 				if (agentTable.TryGetValue(key, out AgentActor agentActor))
 				{
-                    if (agentActor?.charaID == agentData.param.charaID) return agentActor;
+                    if (agentActor?.ChaControl.name == agentData.param?.actor.ChaControl.name) return agentActor;
                 }
             }  
 

--- a/src/AIAPI/MainGame/GameExtensions.cs
+++ b/src/AIAPI/MainGame/GameExtensions.cs
@@ -76,7 +76,7 @@ namespace KKAPI.MainGame
 			{
 				if (agentTable.TryGetValue(key, out AgentActor agentActor))
 				{
-                    if (agentActor?.ChaControl.name == agentData.param?.actor.ChaControl.name) return agentActor;
+                    if (agentActor == agentData.param?.actor) return agentActor;
                 }
             }  
 


### PR DESCRIPTION
Small fix for AIAPI GetNPC returning wrong AgentActor in certain cases