### PR TITLE
Classroom Fix

### DIFF
--- a/src/KKAPI/KKAPI.csproj
+++ b/src/KKAPI/KKAPI.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\..\[ScrewThisNoise] Koikatsu BetterRepack R9.2\BepInEx\plugins\</OutputPath>
+    <OutputPath>..\..\bin\</OutputPath>
     <DefineConstants>TRACE;DEBUG;KK</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/KKAPI/KKAPI.csproj
+++ b/src/KKAPI/KKAPI.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\</OutputPath>
+    <OutputPath>..\..\..\..\[ScrewThisNoise] Koikatsu BetterRepack R9.2\BepInEx\plugins\</OutputPath>
     <DefineConstants>TRACE;DEBUG;KK</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/Shared.KKalike/Maker/MakerInterfaceCreator.KK.cs
+++ b/src/Shared.KKalike/Maker/MakerInterfaceCreator.KK.cs
@@ -312,7 +312,7 @@ namespace KKAPI.Maker
             // Necessary because MoreAccessories copies existing slot, so controls get copied but with no events hooked up
 #if KK
             //KeelsChildNeglect(newSlotTransform, 0); //used to print children paths in case it's needed in the future, like horizontal support or something
-            if (MakerAPI.IsInsideClassMaker() && !MakerAPI.InsideAndLoaded)
+            if (!MakerAPI.InsideAndLoaded)
             {
                 return;//Maker slots are added before CreateCustomAccessoryWindowControls is called. don't create controls yet
             }

--- a/src/Shared.KKalike/Maker/MakerInterfaceCreator.KK.cs
+++ b/src/Shared.KKalike/Maker/MakerInterfaceCreator.KK.cs
@@ -262,10 +262,6 @@ namespace KKAPI.Maker
                         text.Cast<Transform>().First().gameObject.SetActive(false);
                     }
                 }
-#if KK
-                //classroom maker fix, controls will be off until this is called in maker
-                RemoveCustomControlsInSubCategory(slotTransform.GetChild(1).GetChild(0).GetChild(0));
-#endif
                 CreateCustomControlsInSubCategory(slotTransform, _accessoryWindowEntries);
 #if KK
                 var listParent = slotTransform.Cast<Transform>().Where(x => x.name.EndsWith("Top")).First();

--- a/src/Shared.KKalike/Maker/MakerInterfaceCreator.KK.cs
+++ b/src/Shared.KKalike/Maker/MakerInterfaceCreator.KK.cs
@@ -262,6 +262,10 @@ namespace KKAPI.Maker
                         text.Cast<Transform>().First().gameObject.SetActive(false);
                     }
                 }
+#if KK
+                //classroom maker fix, controls will be off until this is called in maker
+                RemoveCustomControlsInSubCategory(slotTransform.GetChild(1).GetChild(0).GetChild(0));
+#endif
                 CreateCustomControlsInSubCategory(slotTransform, _accessoryWindowEntries);
 #if KK
                 var listParent = slotTransform.Cast<Transform>().Where(x => x.name.EndsWith("Top")).First();

--- a/src/Shared.KKalike/Maker/MakerInterfaceCreator.KK.cs
+++ b/src/Shared.KKalike/Maker/MakerInterfaceCreator.KK.cs
@@ -262,10 +262,6 @@ namespace KKAPI.Maker
                         text.Cast<Transform>().First().gameObject.SetActive(false);
                     }
                 }
-#if KK
-                //classroom maker fix, controls will be off until this is called in maker
-                RemoveCustomControlsInSubCategory(slotTransform.GetChild(1).GetChild(0).GetChild(0));
-#endif
                 CreateCustomControlsInSubCategory(slotTransform, _accessoryWindowEntries);
 #if KK
                 var listParent = slotTransform.Cast<Transform>().Where(x => x.name.EndsWith("Top")).First();
@@ -316,7 +312,12 @@ namespace KKAPI.Maker
             // Necessary because MoreAccessories copies existing slot, so controls get copied but with no events hooked up
 #if KK
             //KeelsChildNeglect(newSlotTransform, 0); //used to print children paths in case it's needed in the future, like horizontal support or something
-            newSlotTransform = newSlotTransform.GetChild(1).GetChild(0).GetChild(0);
+            if (MakerAPI.IsInsideClassMaker() && !MakerAPI.InsideAndLoaded)
+            {
+                return;//Maker slots are added before CreateCustomAccessoryWindowControls is called. don't create controls yet
+            }
+            //find parent of Content where controls are placed, additional Slots are copies of first slot
+            newSlotTransform = newSlotTransform.Find("Slot01Top/tglSlot01ScrollView/Viewport");
 #endif
             RemoveCustomControlsInSubCategory(newSlotTransform);
 

--- a/src/Shared.KKalike/Maker/MakerInterfaceCreator.KK.cs
+++ b/src/Shared.KKalike/Maker/MakerInterfaceCreator.KK.cs
@@ -316,7 +316,7 @@ namespace KKAPI.Maker
             {
                 return;//Maker slots are added before CreateCustomAccessoryWindowControls is called. don't create controls yet
             }
-            //find parent of Content where controls are placed, additional Slots are copies of first slot
+            //find parent of Content where controls are placed, additional Slots are copies of first slot as such they are currently named downstream Slot01
             newSlotTransform = newSlotTransform.Find("Slot01Top/tglSlot01ScrollView/Viewport");
 #endif
             RemoveCustomControlsInSubCategory(newSlotTransform);


### PR DESCRIPTION
Slots are copied before scrolling is applied in Classroom maker.
causing duplicate controls to appear.