### PR TITLE
add IsQuitting boolean, Quitting event, and StopOnQuit helper

### DIFF
--- a/src/Shared.Core/KoikatuAPIBase.cs
+++ b/src/Shared.Core/KoikatuAPIBase.cs
@@ -234,7 +234,7 @@ namespace KKAPI
 
         internal void OnQuitting(EventArgs e)
         {
-            if (EnableDebugLogging) Logger.LogWarning("KoikatuAPI - OnQuitting");
+            Logger.LogDebug("The game is quitting!");
             IsQuitting = true;
             Quitting?.Invoke(this, e);
         }

--- a/src/Shared.Core/KoikatuAPIBase.cs
+++ b/src/Shared.Core/KoikatuAPIBase.cs
@@ -1,4 +1,4 @@
-﻿#if AI||HS2||KKS
+#if !PH && !KK && !EC
 #define QUITTING_EVENT_AVAILABLE
 #endif
 

--- a/src/Shared.Core/KoikatuAPIBase.cs
+++ b/src/Shared.Core/KoikatuAPIBase.cs
@@ -65,8 +65,9 @@ namespace KKAPI
         public static bool IsQuitting { get; internal set; }
 
         /// <summary>
-        /// Occurs when application is quitting. Plugins can use this to do things like stop outstanding coroutines to
-        /// prevent shutdown delays.
+        /// Occurs when application is quitting.
+        /// Plugins can use this to do things like write config files and caches, or stop outstanding coroutines to prevent shutdown delays.
+        /// Note: This event might not fire if the game isn't closed cleanly (hard crashes, killed process, closing the console window, etc.).
         /// </summary>
         public event EventHandler Quitting;
 

--- a/src/Shared.Core/KoikatuAPIBase.cs
+++ b/src/Shared.Core/KoikatuAPIBase.cs
@@ -233,6 +233,7 @@ namespace KKAPI
 
         internal void OnQuitting(EventArgs e)
         {
+            if (EnableDebugLogging) Logger.LogWarning("KoikatuAPI - OnQuitting");
             IsQuitting = true;
             Quitting?.Invoke(this, e);
         }

--- a/src/Shared.Core/Utilities/CoroutineUtils.cs
+++ b/src/Shared.Core/Utilities/CoroutineUtils.cs
@@ -250,7 +250,7 @@ namespace KKAPI.Utilities
         /// Create a coroutine that is the same as the supplied coroutine, but will stop early if <see cref="KoikatuAPI.IsQuitting"/> is <c>true</c>.
         /// If the coroutine returns another coroutine, the <see cref="KoikatuAPI.IsQuitting"/> check only runs on the topmost one. Use <see cref="FlattenCo" /> if that's an issue.
         /// </summary>
-        public static IEnumerator StopOnQuit(this IEnumerator enumerator)
+        public static IEnumerator StopCoOnQuit(this IEnumerator enumerator)
         {
             while (!KoikatuAPI.IsQuitting && enumerator.MoveNext())
             {

--- a/src/Shared.Core/Utilities/CoroutineUtils.cs
+++ b/src/Shared.Core/Utilities/CoroutineUtils.cs
@@ -247,104 +247,15 @@ namespace KKAPI.Utilities
         public static readonly WaitForEndOfFrame WaitForEndOfFrame = new WaitForEndOfFrame();
 
         /// <summary>
-        /// Suspends the coroutine execution for the duration of the given yield instruction, or until game is quitting.
+        /// Create a coroutine that is the same as the supplied coroutine, but will stop early if <see cref="KoikatuAPI.IsQuitting"/> is <c>true</c>.
+        /// If the coroutine returns another coroutine, the <see cref="KoikatuAPI.IsQuitting"/> check only runs on the topmost one. Use <see cref="FlattenCo" /> if that's an issue.
         /// </summary>
-        public abstract class ShutdownSafeYieldInstruction : CustomYieldInstruction
+        public static IEnumerator StopOnQuit(this IEnumerator enumerator)
         {
-            private readonly CustomYieldInstruction _innerYieldInstruction;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ShutdownSafeYieldInstruction"/> class.
-            /// </summary>
-            /// <param name="yieldInstruction">The yield instruction to wait for.</param>
-            protected ShutdownSafeYieldInstruction(CustomYieldInstruction yieldInstruction)
+            while (!KoikatuAPI.IsQuitting && enumerator.MoveNext())
             {
-                _innerYieldInstruction = yieldInstruction;
+                yield return enumerator.Current;
             }
-
-            /// <inheritdoc />
-            public override bool keepWaiting => !KoikatuAPI.IsQuitting && _innerYieldInstruction.keepWaiting;
-        }
-
-        /// <summary>
-        /// Suspends the coroutine execution for the given amount of seconds using scaled time, or until game is quitting.
-        /// Should check <see cref="KoikatuAPI.IsQuitting"/> after using.
-        /// </summary>
-        /// <seealso cref="WaitForSeconds"/>
-        public class ShutdownSafeWaitForSeconds : IEnumerator
-        {
-            private readonly float _seconds;
-            private float _endTime = -1f;
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ShutdownSafeWaitForSeconds"/> class.
-            /// </summary>
-            /// <param name="seconds">The given amount of seconds that the yield instruction will wait for.</param>
-            public ShutdownSafeWaitForSeconds(float seconds)
-            {
-                _seconds = seconds;
-            }
-
-            /// <inheritdoc />
-            public bool MoveNext()
-            {
-                if (KoikatuAPI.IsQuitting) return false;
-                if (_endTime < 0f) _endTime = Time.time + _seconds;
-                if (Time.time < _endTime) return true;
-                // reset once timeout reached so it can be used again like WaitForSeconds
-                Reset();
-                return false;
-            }
-
-            /// <inheritdoc />
-            public void Reset()
-            {
-                _endTime = -1f;
-            }
-
-            /// <inheritdoc />
-            public object Current => null;
-        }
-
-        /// <summary>
-        /// Suspends the coroutine execution for the given amount of seconds using unscaled time, or until game is quitting.
-        /// Should check <see cref="KoikatuAPI.IsQuitting"/> after using.
-        /// </summary>
-        /// <seealso cref="WaitForSecondsRealtime"/>
-        public class ShutdownSafeWaitForSecondsRealtime : ShutdownSafeYieldInstruction
-        {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ShutdownSafeWaitForSecondsRealtime"/> class.
-            /// </summary>
-            /// <param name="time">The given amount of seconds that the yield instruction will wait for.</param>
-            public ShutdownSafeWaitForSecondsRealtime(float time) : base(new WaitForSecondsRealtime(time)) { }
-        }
-
-        /// <summary>
-        /// Suspends the coroutine execution until the supplied delegate evaluates to <c>false</c> or the game is quitting.
-        /// Should check <see cref="KoikatuAPI.IsQuitting"/> after using.
-        /// </summary>
-        /// <seealso cref="WaitWhile"/>
-        public class ShutdownSafeWaitWhile : ShutdownSafeYieldInstruction
-        {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ShutdownSafeWaitWhile"/> class.
-            /// </summary>
-            /// <param name="predicate">The predicate to evaluate.</param>
-            public ShutdownSafeWaitWhile(Func<bool> predicate) : base(new WaitWhile(predicate)) { }
-        }
-
-        /// <summary>
-        /// Suspends the coroutine execution until the supplied delegate evaluates to <c>true</c> or the game is quitting.
-        /// Should check <see cref="KoikatuAPI.IsQuitting"/> after using.
-        /// </summary>
-        /// <seealso cref="WaitUntil"/>
-        public class ShutdownSafeWaitUntil : ShutdownSafeYieldInstruction
-        {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ShutdownSafeWaitUntil"/> class.
-            /// </summary>
-            /// <param name="predicate">The predicate to evaluate.</param>
-            public ShutdownSafeWaitUntil(Func<bool> predicate) : base(new WaitUntil(predicate)) { }
         }
     }
 }


### PR DESCRIPTION
Add support to detect/react to application quitting. 

Plugins with long waits can cause game/studio to hang when quitting. Replace things like:

```
yield return new WaitForSecondsRealtime(ConfigSetting.Value * 60);
```
with:
```
yield return new WaitForSecondsRealtime(ConfigSetting.Value * 60).StopOnQuit();
if (KoikatsuAPI.IsQuitting) yield break;
```

and/or:

```
KoikatsuAPI.Instance.Quitting += (s,e) => StopAllCoroutines();
```


