### PR TITLE
[KKS] Fix hscene start hook not calling handlers in VR

### DIFF
--- a/src/KKSAPI/MainGame/GameAPI.Hooks.cs
+++ b/src/KKSAPI/MainGame/GameAPI.Hooks.cs
@@ -61,7 +61,7 @@ namespace KKAPI.MainGame
             public static void StartProcPostVR(MonoBehaviour __instance, ref UniTask __result)
             {
                 var oldResult = __result;
-                __result = oldResult.ContinueWith(() => OnHStart(__instance));
+                __result = oldResult.ContinueWith(() => __instance.StartCoroutine(OnHStart(__instance)));
             }
 
             [HarmonyPostfix]


### PR DESCRIPTION
Apparently UniTask can't run coroutines by itself.
Also tried the IEnumerator.ToUniTask extension, but it complained about a bunch of missing assemblies (and it's incomplete according to the [docs ](https://github.com/Cysharp/UniTask#ienumeratortounitask-limitation) anyway).