### PR TITLE
Reorder GameApi.GetCurrentHeroine code to work with some edge cases

### DIFF
--- a/src/KKAPI/MainGame/GameApi.cs
+++ b/src/KKAPI/MainGame/GameApi.cs
@@ -526,18 +526,18 @@ namespace KKAPI.MainGame
         /// </summary>
         public static SaveData.Heroine GetCurrentHeroine()
         {
-            var advScene = GetADVScene();
-            if (advScene != null)
-            {
-                if (advScene.Scenario != null && advScene.Scenario.currentHeroine != null)
-                    return advScene.Scenario.currentHeroine;
-                if (advScene.nowScene is TalkScene s && s.targetHeroine != null)
-                    return s.targetHeroine;
-            }
-
             var hFlag = GameObject.FindObjectOfType<HFlag>();
             if (hFlag != null)
                 return hFlag.GetLeadingHeroine();
+
+            var advScene = GetADVScene();
+            if (advScene != null)
+            {
+                if (advScene.nowScene is TalkScene s && s.targetHeroine != null)
+                    return s.targetHeroine;
+                if (advScene.Scenario != null && advScene.Scenario.currentHeroine != null)
+                    return advScene.Scenario.currentHeroine;
+            }
 
             var talkScene = GetTalkScene();
             if (talkScene != null)

--- a/src/KKSAPI/MainGame/GameApi.cs
+++ b/src/KKSAPI/MainGame/GameApi.cs
@@ -513,18 +513,18 @@ namespace KKAPI.MainGame
         /// </summary>
         public static SaveData.Heroine GetCurrentHeroine()
         {
-            var advScene = GetADVScene();
-            if (advScene != null)
-            {
-                if (advScene.Scenario != null && advScene.Scenario.currentHeroine != null)
-                    return advScene.Scenario.currentHeroine;
-                if (advScene.nowScene is TalkScene s && s.targetHeroine != null)
-                    return s.targetHeroine;
-            }
-
             var hFlag = GameObject.FindObjectOfType<HFlag>();
             if (hFlag != null)
                 return hFlag.GetLeadingHeroine();
+
+            var advScene = GetADVScene();
+            if (advScene != null)
+            {
+                if (advScene.nowScene is TalkScene s && s.targetHeroine != null)
+                    return s.targetHeroine;
+                if (advScene.Scenario != null && advScene.Scenario.currentHeroine != null)
+                    return advScene.Scenario.currentHeroine;
+            }
 
             var talkScene = GetTalkScene();
             if (talkScene != null)


### PR DESCRIPTION
Hi,

GetCurrentHeroine() almost always fail to get the correct heroine when the heroine ask for sex and/or when the player start interaction with the heroine when she is masturbating.

The changes are:

1. Try first to see if an H scene is active and get heroine using HFlag extension this takes care when heroine ask for sex.
2. When checking with GetADVScene() first check if advScene.nowScene is a TalkScene this takes care of the masturbation case.

Any other case behaves the same returning the correct heroine when there was one currently in focus.

While debugging I always checked what every method result was.

PS: Noted that also fails if the girl start talk with player.