### PR TITLE
[KK] Add TextureUtils.CorrectColorSpaceForKoikatu for KK UI textures

### DIFF
--- a/src/Shared.Core/Utilities/IMGUI/InterfaceMaker.cs
+++ b/src/Shared.Core/Utilities/IMGUI/InterfaceMaker.cs
@@ -41,12 +41,14 @@ namespace KKAPI.Utilities
 
             // Load the custom skin from resources
             _boxBackground = ResourceUtils.GetEmbeddedResource(lightVersion ? "guisharp-box-light.png" : "guisharp-box.png").LoadTexture();
+            _boxBackground.CorrectColorSpaceForLinear();
             Object.DontDestroyOnLoad(_boxBackground);
             newSkin.box.onNormal.background = null;
             newSkin.box.normal.background = _boxBackground;
             newSkin.box.normal.textColor = Color.white;
 
             _winBackground = ResourceUtils.GetEmbeddedResource(lightVersion ? "guisharp-window-light.png" : "guisharp-window.png").LoadTexture();
+            _winBackground.CorrectColorSpaceForLinear();
             Object.DontDestroyOnLoad(_winBackground);
             newSkin.window.onNormal.background = null;
             newSkin.window.normal.background = _winBackground;

--- a/src/Shared.Core/Utilities/IMGUI/InterfaceMaker.cs
+++ b/src/Shared.Core/Utilities/IMGUI/InterfaceMaker.cs
@@ -41,14 +41,12 @@ namespace KKAPI.Utilities
 
             // Load the custom skin from resources
             _boxBackground = ResourceUtils.GetEmbeddedResource(lightVersion ? "guisharp-box-light.png" : "guisharp-box.png").LoadTexture();
-            _boxBackground.CorrectColorSpaceForLinear();
             Object.DontDestroyOnLoad(_boxBackground);
             newSkin.box.onNormal.background = null;
             newSkin.box.normal.background = _boxBackground;
             newSkin.box.normal.textColor = Color.white;
 
             _winBackground = ResourceUtils.GetEmbeddedResource(lightVersion ? "guisharp-window-light.png" : "guisharp-window.png").LoadTexture();
-            _winBackground.CorrectColorSpaceForLinear();
             Object.DontDestroyOnLoad(_winBackground);
             newSkin.window.onNormal.background = null;
             newSkin.window.normal.background = _winBackground;

--- a/src/Shared.Core/Utilities/TextureUtils.cs
+++ b/src/Shared.Core/Utilities/TextureUtils.cs
@@ -53,7 +53,7 @@ namespace KKAPI.Utilities
         /// Gamma-encodes an sRGB texture's RGB so it isn't sampled too dark in Linear color space.
         /// Fixes UI PNGs on Koikatsu (Unity 5.6); no-op on every other game. Alpha is untouched; the texture must be readable.
         /// </summary>
-        public static void CorrectColorSpaceForLinear(this Texture2D texture)
+        public static void CorrectColorSpaceForKoikatu(this Texture2D texture)
         {
             if (!texture) throw new ArgumentNullException(nameof(texture));
 #if KK

--- a/src/Shared.Core/Utilities/TextureUtils.cs
+++ b/src/Shared.Core/Utilities/TextureUtils.cs
@@ -45,6 +45,37 @@ namespace KKAPI.Utilities
             return tex;
         }
 
+#if KK
+        private static byte[] _gammaLut;
+#endif
+
+        /// <summary>
+        /// Gamma-encodes an sRGB texture's RGB so it isn't sampled too dark in Linear color space.
+        /// Fixes UI PNGs on Koikatsu (Unity 5.6); no-op on every other game. Alpha is untouched; the texture must be readable.
+        /// </summary>
+        public static void CorrectColorSpaceForLinear(this Texture2D texture)
+        {
+            if (!texture) throw new ArgumentNullException(nameof(texture));
+#if KK
+            if (_gammaLut == null)
+            {
+                _gammaLut = new byte[256];
+                for (int i = 0; i < 256; i++)
+                    _gammaLut[i] = (byte)Mathf.Clamp(Mathf.RoundToInt(Mathf.LinearToGammaSpace(i / 255f) * 255f), 0, 255);
+            }
+
+            var pixels = texture.GetPixels32();
+            for (int i = 0; i < pixels.Length; i++)
+            {
+                pixels[i].r = _gammaLut[pixels[i].r];
+                pixels[i].g = _gammaLut[pixels[i].g];
+                pixels[i].b = _gammaLut[pixels[i].b];
+            }
+            texture.SetPixels32(pixels);
+            texture.Apply(false);
+#endif
+        }
+
         /// <summary>
         /// Create a sprite based on this texture.
         /// </summary>


### PR DESCRIPTION
## Description
KK (Unity 5.6, Linear) samples sRGB UI PNGs too dark. Add a public gamma-LUT fixer (KK-only, no-op elsewhere) and apply it to the InterfaceMaker skin.

## Motivation and Context
KKs VE window and IMGUI windows in general were too dark. 

## How Has This Been Tested?
KK and HS2 satrted and checked if colors are correct.

Performance test:
| Size | Pixels | Iters | M2 Color32+LUT |
|--------|--------|--------|--------|
| VE-small 32 | 1,024 | 10000 | 0.007 ms |
| medium 256 | 65,536 | 1000 | 0.345 ms |
| multi-MB 2048 | 4,194,304 | 100 | 19.999 ms |
| 4K 4096 | 16,777,216 | 50 | 66.620 ms |
| 8K 8192 | 67,108,864 | 10 | 286.915 ms | 

ms are average over the iterations NOT total time.
Performance test was made in a clean Unity project, since i tested multiple ways.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
